### PR TITLE
Fixing issues with boringSSL's X509_check_host

### DIFF
--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,6 +1,21 @@
 {
-    "x": ["test/"],
-    "requires": { 
-      "platform": [  "OpenSSL::+SSL", "OpenSSL::+Crypto" ]
+  "x": [
+    "test/"
+  ],
+  "requires": {
+    "nxxm/boringssl": {
+      "@": ":358175c062c3a3964d4734df4b122e6af851def0",
+      "u": true,
+      "packages": [
+        "OpenSSL",
+        "BoringSSL"
+      ],
+      "targets": [
+        "OpenSSL::SSL",
+        "OpenSSL::Crypto",
+        "BoringSSL::decrepit"
+      ],
+      "find_mode": " "
     }
+  }
 }

--- a/src/smtp.c
+++ b/src/smtp.c
@@ -1843,7 +1843,7 @@ smtp_tls_init(struct smtp *const smtp,
       SSL_free(smtp->tls);
       return -1;
     }
-    if(X509_check_host(X509_cert_peer, server, 0, 0, NULL) != 1){
+    if(X509_check_host(X509_cert_peer, server, strlen(server), 0, NULL) != 1){
       SSL_CTX_free(smtp->tls_ctx);
       SSL_free(smtp->tls);
       return -1;


### PR DESCRIPTION
`X509_check_host` is behaving a bit differently by not determining the length of the passed in expected server name thus failing systematically in the original implementation